### PR TITLE
Replace wallet icon in the header

### DIFF
--- a/modules/nav/NavbarWalletConnectButton.tsx
+++ b/modules/nav/NavbarWalletConnectButton.tsx
@@ -104,7 +104,9 @@ export default function NavbarWalletConnectButton() {
                         ) : earlyLudwig ? (
                           <Image src={VertekAlpha} width="20px" height="20px"   />
                         ) : (
-                          <Image src={VertekWhite} width="20px" alt="your-profile" />
+                          <Box borderRadius="full" overflow="hidden" width="20px" height="20px">
+                            <Image src={ "https://avatar.tobi.sh/" + account.address + "?size=20" } width="100%" height="100%" alt="your-profile" />
+                          </Box>
                         )}
                         <Text
                           display={{ base: 'none', sm: 'inline' }} 

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
   },
 
   images: {
+    domains: ['avatar.tobi.sh'],
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
This replaces the white Vertek icon from the wallet button for an avatar used previously by Aequinox.

I'm not overly happy with the approach though, feel free to reject it.

Partly addresses this comment: https://github.com/vertekfi/dex-frontend/issues/12#issuecomment-1404989144.