### PR TITLE
Lock dialog locked amount and button fixed

### DIFF
--- a/modules/voting/lock/LockPreviewModal/LockPreviewModal.tsx
+++ b/modules/voting/lock/LockPreviewModal/LockPreviewModal.tsx
@@ -119,6 +119,7 @@ export function LockPreviewModal(props: Props) {
             lockEndDate={props.lockEndDate}
             lockType={props.lockType}
             onSuccess={handleSuccess}
+            onClose={props.onClose}
           />
         </Box>
       </ModalContent>

--- a/modules/voting/lock/LockPreviewModal/components/LockActions.tsx
+++ b/modules/voting/lock/LockPreviewModal/components/LockActions.tsx
@@ -20,6 +20,7 @@ type Props = {
   lockEndDate: string;
   lockType: LockType[];
   onSuccess: () => void;
+  onClose: () => void;
 };
 
 export function LockActions(props: Props) {
@@ -133,7 +134,7 @@ export function LockActions(props: Props) {
       isLoading={isLoadingAllowances || !txSteps.length}
       loadingButtonText="Awaiting confirmation.."
       completeButtonText="Lock complete"
-      onCompleteButtonClick={() => {}}
+      onCompleteButtonClick={() => { props.onClose(); }}
       onSubmit={(id) => {
         if (id === 'approve') {
           approve(networkConfig.balancer.votingEscrow.veAddress);

--- a/modules/voting/lock/LockPreviewModal/components/LockSummary.tsx
+++ b/modules/voting/lock/LockPreviewModal/components/LockSummary.tsx
@@ -21,7 +21,7 @@ export function LockSummary(props: Props) {
     props.lockablePool.dynamicData.totalShares,
   );
 
-  const fiatTotalLockedAmount = poolShares.times(props.currentVeBalance).toString();
+  const fiatTotalLockedAmount = poolShares.times(props.currentVeBalance.replace(/,/g, '')).toString();
   const fiatTotalLockAmount = poolShares.times(props.lockAmount).toString();
   const fiatTotalLpTokens = poolShares.times(props.totalLpTokens).toString();
 


### PR DESCRIPTION
This fixes https://github.com/vertekfi/dex-frontend/issues/115 - total already locked. When the number contains comma (above 999) it messes up with the math functions. I used gsub to just remove the comma, I believe/hope this comma doesn't come from a locale on users machine.

And it also fixes https://github.com/vertekfi/dex-frontend/issues/111 - I was fighting this for a bit. Hopefully I got it right.